### PR TITLE
fix issue where pjsip_loaded and sip_loaded flags are never both true

### DIFF
--- a/custom_components/asterisk/__init__.py
+++ b/custom_components/asterisk/__init__.py
@@ -45,9 +45,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if event.name == "PeerlistComplete":
             _LOGGER.debug("SIP loaded.")
             sip_loaded = True
+            hass.data[DOMAIN][entry.entry_id][SIP_LOADED] = True
         elif event.name == "EndpointListComplete":
             _LOGGER.debug("PJSIP loaded.")
             pjsip_loaded = True
+            hass.data[DOMAIN][entry.entry_id][PJSIP_LOADED] = True
         
         if sip_loaded and pjsip_loaded:
             _LOGGER.debug("Both SIP and PJSIP loaded. Loading platforms.")

--- a/custom_components/asterisk/manifest.json
+++ b/custom_components/asterisk/manifest.json
@@ -10,9 +10,9 @@
     "homekit": {},
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/TECH7Fox/Asterisk-integration/issues",
+    "loggers": ["custom_components.asterisk"],
     "requirements": ["asterisk-ami==0.1.6"],
     "ssdp": [],
     "version": "1.0.2",
-    "zeroconf": [],
-    "loggers": ["custom_components.asterisk"]
+    "zeroconf": []
 }

--- a/custom_components/asterisk/manifest.json
+++ b/custom_components/asterisk/manifest.json
@@ -13,5 +13,6 @@
     "requirements": ["asterisk-ami==0.1.6"],
     "ssdp": [],
     "version": "1.0.2",
-    "zeroconf": []
+    "zeroconf": [],
+    "loggers": ["custom_components.asterisk"]
 }


### PR DESCRIPTION
in the may 8th commit, a bug was introduced where both pjsip_loaded and sip_loaded must be true to complete creating devices but these values, while set locally, are never written back into hass.data so both are never true at the same time.